### PR TITLE
[NOD-836] feat: handle errors during data migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pagoPA Functions fdr-xml-to-json-fn
 
 Java fdr-re-to-datastore Azure Function.
-The function aims to dump RE sent via Azure Event Hub to a CosmosDB, with a TTL of 120 days, and to an Azure Table Storage with a TTL of 10 years.
+The function aims to convert FdR reports from XML format to JSON format.
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pagopa_pagopa-fdr-re-to-datastore&metric=alert_status)](https://sonarcloud.io/dashboard?id=pagopa_pagopa-fdr-re-to-datastore)
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ The function aims to dump RE sent via Azure Event Hub to a CosmosDB, with a TTL 
 
 ## Run locally with Maven
 
+In order to autogenerate the required classes, please run the command:  
 `mvn clean package`
 
+In order to test the Azure Function in local environment, please run the command:
 `mvn azure-functions:run`
 
 ### Test

--- a/host.json
+++ b/host.json
@@ -5,23 +5,28 @@
     "version": "[4.0.0, 5.0.0)"
   },
   "extensions": {
+    "tracing": {
+      "traceInputsAndOutputs": false,
+      "traceReplayEvents": false
+    },
     "http": {
       "routePrefix": ""
     }
   },
   "functions": [ "Info", "BlobFdrXmlToJsonEventProcessor", "XmlErrorRetry" ],
   "logging": {
+    "logLevel": {
+      "default": "Error",
+      "Function.BlobFdrXmlToJsonEventProcessor": "Information",
+      "Function.XmlErrorRetry": "Information"
+    },
     "applicationInsights": {
       "samplingSettings": {
-        "isEnabled": false
+        "isEnabled": true,
+        "maxTelemetryItemsPerSecond": 5,
+        "includedTypes": "PageView;Trace;Dependency;Request",
+        "excludedTypes": "Exception;Event;CustomEvent"
       }
-    },
-    "fileLoggingMode": "always",
-    "logLevel": {
-      "default": "Information",
-      "Host.Results": "Error",
-      "Function": "Information",
-      "Host.Aggregator": "Trace"
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>fdrxmltojson</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-1-NOD-836-fdr-gestire-gli-errori-di-riversamento</version>
     <packaging>jar</packaging>
 
     <name>FDR XML to JSON Fn</name>

--- a/src/main/java/it/gov/pagopa/fdrxmltojson/FdrXmlToJson.java
+++ b/src/main/java/it/gov/pagopa/fdrxmltojson/FdrXmlToJson.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Lists;
 import com.microsoft.azure.functions.ExecutionContext;
 import com.microsoft.azure.functions.annotation.BindingName;
 import com.microsoft.azure.functions.annotation.BlobTrigger;
+import com.microsoft.azure.functions.annotation.ExponentialBackoffRetry;
 import com.microsoft.azure.functions.annotation.FunctionName;
 import it.gov.digitpa.schemas._2011.pagamenti.CtDatiSingoliPagamenti;
 import it.gov.digitpa.schemas._2011.pagamenti.CtFlussoRiversamento;
@@ -47,6 +48,8 @@ import java.util.stream.Collectors;
  * Azure Functions with Azure Queue trigger.
  */
 public class FdrXmlToJson {
+
+	private static final Integer MAX_RETRY_COUNT = 5;
 	private static final String NODO_INVIA_FLUSSO_RENDICONTAZIONE = "nodoInviaFlussoRendicontazione";
 
 
@@ -110,6 +113,7 @@ public class FdrXmlToJson {
 	}
 
     @FunctionName("BlobFdrXmlToJsonEventProcessor")
+	@ExponentialBackoffRetry(maxRetryCount = 5, maximumInterval = "00:15:00", minimumInterval = "00:00:10")
     public void processNodoReEvent (
 			@BlobTrigger(
 					name = "xmlTrigger",
@@ -119,12 +123,21 @@ public class FdrXmlToJson {
 			@BindingName("fileName") String fileName,
 			final ExecutionContext context) {
 
+		String errorCause = null;
+		boolean isPersistenceOk = true;
+		Throwable causedBy = null;
+		int retryIndex = context.getRetryContext() == null ? -1 : context.getRetryContext().getRetrycount();
+
 		Logger logger = context.getLogger();
-		logger.info("Java Blob trigger function processed a blob.\n Name: " + fileName + "\n Size: " + content.length + " Bytes");
+		if (retryIndex == MAX_RETRY_COUNT) {
+			logger.log(Level.WARNING, () -> String.format("[ALERT][FdrXmlToJson][LAST_RETRY] Performing last retry for blob processing: InvocationId [%s], File name: %s", context.getInvocationId(), fileName));
+		}
 
 		String fdrBk = null;
 		String pspIdBk = null;
 		try {
+			logger.log(Level.INFO, () -> String.format("Performing blob processing: InvocationId [%s], Retry Attempt [%d], File name: %s", context.getInvocationId(), retryIndex, fileName));
+
 			// read xml
 			Document document = loadXMLString(content);
 			Element element = searchNodeByName(document, NODO_INVIA_FLUSSO_RENDICONTAZIONE);
@@ -137,60 +150,63 @@ public class FdrXmlToJson {
 			String pspId = nodoInviaFlussoRendicontazioneRequest.getIdentificativoPSP();
 			pspIdBk = pspId;
 
-			logger.info("Process fdr=["+fdr+"], pspId=["+pspId+"]");
-
 			// create body for create FDR
 			CreateRequest createRequest = getCreateRequest(nodoInviaFlussoRendicontazioneRequest, ctFlussoRiversamento);
+
 			// call create FDR
-			logger.info("Calling... "+HttpEventTypeEnum.INTERNAL_CREATE.name());
 			manageHttpError(logger, HttpEventTypeEnum.INTERNAL_CREATE, fileName, fdr, pspId, () ->
 				getPspApi().internalCreate(fdr, pspId, createRequest)
 			);
 
 			// create body for addPayment FDR (partitioned)
 			List<CtDatiSingoliPagamenti> datiSingoliPagamenti = ctFlussoRiversamento.getDatiSingoliPagamenti();
-			logger.info("Tot CtDatiSingoliPagamenti ["+datiSingoliPagamenti.size()+"]");
 			int partitionSize = Integer.parseInt(addPaymentRequestPartitionSize);
 			List<AddPaymentRequest> addPaymentRequestList = getAddPaymentRequestListPartioned(datiSingoliPagamenti, partitionSize);
-			logger.info("Tot AddPaymentRequest=["+addPaymentRequestList.size()+"], partioned by ["+partitionSize+"]");
-			// call addPayment FDR for every patition
+			// call addPayment FDR for every partition
 			for(AddPaymentRequest addPaymentRequest : addPaymentRequestList) {
-				logger.info("Calling... "+HttpEventTypeEnum.INTERNAL_ADD_PAYMENT.name()+" (partition=" + addPaymentRequestList.indexOf(addPaymentRequest) + 1 + ", tot payments=" + addPaymentRequest.getPayments().size() + ")");
 				manageHttpError(logger, HttpEventTypeEnum.INTERNAL_ADD_PAYMENT, fileName, fdr, pspId, () ->
 					getPspApi().internalAddPayment(fdr, pspId, addPaymentRequest)
 				);
 			}
 
 			// call publish FDR
-			logger.info("Calling... "+HttpEventTypeEnum.INTERNAL_PUBLISH.name());
 			manageHttpError(logger, HttpEventTypeEnum.INTERNAL_PUBLISH, fileName, fdr, pspId, () ->
 				getPspApi().internalPublish(fdr, pspId)
 			);
 
 			// delete BLOB
-			logger.info("Deleting... blob file "+fileName);
-			try{
+			try {
 				getBlobContainerClient().getBlobClient(fileName).delete();
 			} catch (Exception e) {
 				Instant now = Instant.now();
 				ErrorEnum error = ErrorEnum.DELETE_BLOB_ERROR;
-				String message = getErrorMessage(error, fileName, now);
-				logger.log(Level.SEVERE, message, e);
 				sendGenericError(logger, now, fileName, fdr, pspId, error, e);
-				throw new AppException(message, e);
+
+				isPersistenceOk = false;
+				errorCause = getErrorMessage(error, fileName, now);
+				causedBy = e;
 			}
 
-			logger.info("Done processing events");
 		} catch (AppException e) {
-			logger.info("Failure processing events");
+			isPersistenceOk = false;
+			errorCause = e.getMessage();
+			causedBy = e;
+
 		} catch (Exception e) {
 			Instant now = Instant.now();
 			ErrorEnum error = ErrorEnum.GENERIC_ERROR;
-			String message = getErrorMessage(error, fileName, now);
-			logger.log(Level.SEVERE, message, e);
 			sendGenericError(logger, now, fileName, fdrBk, pspIdBk, error, e);
-			logger.info("Failure processing events");
+
+			isPersistenceOk = false;
+			errorCause = getErrorMessage(error, fileName, now);
+			causedBy = e;
         }
+
+		if (!isPersistenceOk) {
+			String finalErrorCause = errorCause;
+			logger.log(Level.SEVERE, () -> finalErrorCause);
+			throw new AppException(errorCause, causedBy);
+		}
     }
 
 	private enum HttpEventTypeEnum {
@@ -205,10 +221,10 @@ public class FdrXmlToJson {
 	}
 
 	private static String getHttpErrorMessage(ErrorEnum errorEnum, String fileName, HttpEventTypeEnum httpEventTypeEnum, String errorCode, Instant now){
-		return "[ALERT] [error="+errorEnum.name()+"] [fileName="+fileName+"] [httpEventTypeEnum="+httpEventTypeEnum.name()+"] [errorCode="+errorCode+"] Http error at "+ now;
+		return "[ALERT][FdrXmlToJson]["+errorEnum.name()+"] [fileName="+fileName+"] [httpEventTypeEnum="+httpEventTypeEnum.name()+"] [errorCode="+errorCode+"] Http error at "+ now;
 	}
 	private static String getErrorMessage(ErrorEnum errorEnum, String fileName, Instant now){
-		return "[ALERT] [error="+errorEnum.name()+"] [fileName="+fileName+"] Http error at "+ now;
+		return "[ALERT][FdrXmlToJson]["+errorEnum.name()+"] [fileName="+fileName+"] Http error at "+ now;
 	}
 	private static<T> void manageHttpError(Logger logger, HttpEventTypeEnum httpEventTypeEnum, String fileName, String fdr, String pspId, SupplierWithApiException<T> fn){
 		try {
@@ -224,7 +240,6 @@ public class FdrXmlToJson {
 			Instant now = Instant.now();
 			ErrorEnum error = ErrorEnum.HTTP_ERROR;
 			String message = getHttpErrorMessage(error, fileName, httpEventTypeEnum, errorCode, now);
-			logger.log(Level.SEVERE, message, e);
 			sendHttpError(logger, now, fileName, fdr, pspId, error, httpEventTypeEnum, errorResposne, errorCode, e);
 			throw new AppException(message, e);
 		}
@@ -252,7 +267,6 @@ public class FdrXmlToJson {
 
 		String partitionKey =  now.toString().substring(0,10);
 
-		logger.info("Send to "+tableName+" record with "+AppConstant.columnFieldId+"="+id);
 		TableClient tableClient = getTableServiceClient().getTableClient(tableName);
 		TableEntity entity = new TableEntity(partitionKey, id);
 		entity.setProperties(errorMap);

--- a/src/main/java/it/gov/pagopa/fdrxmltojson/FdrXmlToJson.java
+++ b/src/main/java/it/gov/pagopa/fdrxmltojson/FdrXmlToJson.java
@@ -112,8 +112,16 @@ public class FdrXmlToJson {
 		return blobContainerClient;
 	}
 
+	/*
+	Executing this Azure Function in exponential retry, with time:
+	- retry 0: 0
+	- retry 1: 10s
+	- retry 2: 20s
+	- retry 3: 40s
+	- ...
+	 */
     @FunctionName("BlobFdrXmlToJsonEventProcessor")
-	@ExponentialBackoffRetry(maxRetryCount = 5, maximumInterval = "00:15:00", minimumInterval = "00:00:10")
+	@ExponentialBackoffRetry(maxRetryCount = 10, maximumInterval = "01:30:00", minimumInterval = "00:00:10")
     public void processNodoReEvent (
 			@BlobTrigger(
 					name = "xmlTrigger",


### PR DESCRIPTION
This PR contains the updates made in order to correctly handle the errors on Azure Function.  
These updates refers to the explicit execution retry, made by the exponential backoff algorithm, in order to correctly re-execute the main logic avoiding throw the queue event on poison ones.  
The updates provide also an update on logging process, removing not necessary logs and adding ones that will be used in future implementation of Opsgenie alerting.

#### List of Changes
 - Add `ExponentialBackoffRetry` annotation in order to explicitly activate Azure Function's retry operation by exponential backoff algorithm
 - Updated logs, removing unnecessaries ones and enhancing ones that will be used by alerting processes
 - Updated `host.json`, reducing log generation to strict necessary in order to reduce pricing on Application Insights 

#### Motivation and Context
These changes are required in order to align Azure Function to the explicit retry and error handling made in other functions used in pagoPA platform

#### How Has This Been Tested?
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.