### PR TITLE
[NOD-847] fix: resolved error on psp name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>fdrxmltojson</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.1-1-NOD-847-fdr-errore-in-conversione-xml-json</version>
     <packaging>jar</packaging>
 
     <name>FDR XML to JSON Fn</name>

--- a/src/main/java/it/gov/pagopa/fdrxmltojson/FdrXmlToJson.java
+++ b/src/main/java/it/gov/pagopa/fdrxmltojson/FdrXmlToJson.java
@@ -327,7 +327,7 @@ public class FdrXmlToJson {
 		sender.setType(typeMap.get(tipoIdentificativoUnivoco));
 		sender.setId(ctFlussoRiversamento.getIstitutoMittente().getIdentificativoUnivocoMittente().getCodiceIdentificativoUnivoco());
 		sender.setPspId(nodoInviaFlussoRendicontazioneRequest.getIdentificativoPSP());
-		sender.setPspName(ctFlussoRiversamento.getIstitutoMittente().getDenominazioneMittente());
+		sender.setPspName(Optional.ofNullable(ctFlussoRiversamento.getIstitutoMittente().getDenominazioneMittente()).orElse(""));
 		sender.setPspBrokerId(nodoInviaFlussoRendicontazioneRequest.getIdentificativoIntermediarioPSP());
 		sender.setChannelId(nodoInviaFlussoRendicontazioneRequest.getIdentificativoCanale());
 		sender.setPassword(nodoInviaFlussoRendicontazioneRequest.getPassword());


### PR DESCRIPTION
This PR contains a fix made on Function in order to resolve a bug during reconciliation process. The bug is related to a wrong mapping on DTOs to be passed as input to FdR-Fase3: the field `pspName` is required in FdR-Fase3 app and so, if is not correctly set in Fase1's XML it causes a `400 Bad request` during conversion step.

#### List of Changes
Set empty character on `pspName` if no value is set in FdR-Fase1's XML

#### Motivation and Context
This fix is required in order to resolve a bug during XML-to-JSON conversion

#### How Has This Been Tested?
 - Tested in DEV environment
 - Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.