### PR TITLE
fix: [PIDM-843] Resolving problems on auto-conversion from XML to JSON

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: pagopa-fdr-xml-to-json
 description: AppFn to convert SOAP FdR to JSON FdR
-version: 0.97.0
-appVersion: 1.0.8
+version: 0.98.0
+appVersion: 1.0.8-1-fix-conversion-indicedatisingolopagamento
 dependencies:
   - name: microservice-chart
     version: 7.1.1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: pagopa-fdr-xml-to-json
 description: AppFn to convert SOAP FdR to JSON FdR
-version: 0.98.0
-appVersion: 1.0.8-1-fix-conversion-indicedatisingolopagamento
+version: 0.99.0
+appVersion: 1.0.8-2-PIDM-843
 dependencies:
   - name: microservice-chart
     version: 7.1.1

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-xml-to-json
-    tag: "1.0.8-1-fix-conversion-indicedatisingolopagamento"
+    tag: "1.0.8-2-PIDM-843"
     pullPolicy: Always
   livenessProbe:
     handlerType: tcpSocket

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-xml-to-json
-    tag: "1.0.8"
+    tag: "1.0.8-1-fix-conversion-indicedatisingolopagamento"
     pullPolicy: Always
   livenessProbe:
     handlerType: tcpSocket

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-xml-to-json
-    tag: "1.0.8-1-fix-conversion-indicedatisingolopagamento"
+    tag: "1.0.8-2-PIDM-843"
     pullPolicy: Always
   livenessProbe:
     handlerType: tcpSocket

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-xml-to-json
-    tag: "1.0.8"
+    tag: "1.0.8-1-fix-conversion-indicedatisingolopagamento"
     pullPolicy: Always
   livenessProbe:
     handlerType: tcpSocket

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-xml-to-json
-    tag: "1.0.8-1-fix-conversion-indicedatisingolopagamento"
+    tag: "1.0.8-2-PIDM-843"
     pullPolicy: Always
   livenessProbe:
     handlerType: tcpSocket

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-xml-to-json
-    tag: "1.0.8"
+    tag: "1.0.8-1-fix-conversion-indicedatisingolopagamento"
     pullPolicy: Always
   livenessProbe:
     handlerType: tcpSocket

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "FdR - XML to JSON ${service}",
-    "version": "1.0.8-1-fix-conversion-indicedatisingolopagamento",
+    "version": "1.0.8-2-PIDM-843",
     "description": "FDR XML to JSON API REST"
   },
   "paths": {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "FdR - XML to JSON ${service}",
-    "version": "1.0.8",
+    "version": "1.0.8-1-fix-conversion-indicedatisingolopagamento",
     "description": "FDR XML to JSON API REST"
   },
   "paths": {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>fdrxmltojson</artifactId>
-    <version>1.0.8-1-fix-conversion-indicedatisingolopagamento</version>
+    <version>1.0.8-2-PIDM-843</version>
     <packaging>jar</packaging>
 
     <name>FDR XML to JSON Fn</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>fdrxmltojson</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.8-1-fix-conversion-indicedatisingolopagamento</version>
     <packaging>jar</packaging>
 
     <name>FDR XML to JSON Fn</name>

--- a/src/main/java/it/gov/pagopa/fdrxmltojson/util/FdR3ClientUtil.java
+++ b/src/main/java/it/gov/pagopa/fdrxmltojson/util/FdR3ClientUtil.java
@@ -105,7 +105,7 @@ public class FdR3ClientUtil {
     private Payment getPayment(CtDatiSingoliPagamenti ctDatiSingoliPagamenti, int index){
         Payment payment = new Payment();
         payment.setIndex((long) index);
-        payment.setIdTransfer(ctDatiSingoliPagamenti.getIndiceDatiSingoloPagamento().longValue());
+        payment.setIdTransfer(Optional.ofNullable(ctDatiSingoliPagamenti.getIndiceDatiSingoloPagamento()).orElse(1).longValue());
         payment.setIuv(ctDatiSingoliPagamenti.getIdentificativoUnivocoVersamento());
         payment.setIur(ctDatiSingoliPagamenti.getIdentificativoUnivocoRiscossione());
         payment.setPay(ctDatiSingoliPagamenti.getSingoloImportoPagato().doubleValue());

--- a/src/main/java/it/gov/pagopa/fdrxmltojson/util/FdR3ClientUtil.java
+++ b/src/main/java/it/gov/pagopa/fdrxmltojson/util/FdR3ClientUtil.java
@@ -93,12 +93,12 @@ public class FdR3ClientUtil {
 
     private Receiver getReceiver(NodoInviaFlussoRendicontazioneRequest nodoInviaFlussoRendicontazioneRequest, CtFlussoRiversamento ctFlussoRiversamento){
         String organizationId = nodoInviaFlussoRendicontazioneRequest.getIdentificativoDominio();
-        String organizationName = ctFlussoRiversamento.getIstitutoRicevente().getDenominazioneRicevente();
+        String organizationName = FormatterUtil.sanitize(ctFlussoRiversamento.getIstitutoRicevente().getDenominazioneRicevente());
 
         Receiver receiver = new Receiver();
         receiver.setId(ctFlussoRiversamento.getIstitutoRicevente().getIdentificativoUnivocoRicevente().getCodiceIdentificativoUnivoco());
         receiver.setOrganizationId(organizationId);
-        receiver.setOrganizationName(organizationName!=null?organizationName:organizationId);
+        receiver.setOrganizationName(organizationName !=null ? organizationName : organizationId);
         return receiver;
     }
 

--- a/src/main/java/it/gov/pagopa/fdrxmltojson/util/FormatterUtil.java
+++ b/src/main/java/it/gov/pagopa/fdrxmltojson/util/FormatterUtil.java
@@ -10,4 +10,8 @@ public class FormatterUtil {
         String suffix = String.format(" [sessionId: %s][invocationId: %s][psp: %s][filename: %s]", sessionId, invocationId, pspId, fileName);
         return String.format(message, args) + suffix;
     }
+
+    public static String sanitize(String input) {
+        return input == null ? null : input.replaceAll("[\\n\\r\\t]", "");
+    }
 }


### PR DESCRIPTION
This PR contains some little fixes made in order to resolve some errors during auto-conversion. In particular:
 - if Fase1's flows were sent with a single payment, the optional field `datiSingoliPagamenti.indiceDatiSingoloPagamento` is not set, so the conversion (that always required this field) failed during `add payment` step
 - if Fase1's flows were sent with field `organizationName` in strange formatting, the conversion failed during `create empty flow` step due to regex-rule break in FdR3

Those fixes resolve these problems and now the conversion can be made without other problems.

#### List of Changes
 - Sanitizing `organizationName` fields taken from strangely formatted `IstitutoRicevente.DenominazioneRicevente` field
 - Setting default value to `1` if `datiSingoliPagamenti.indiceDatiSingoloPagamento` is not set in flows with single payment

#### Motivation and Context
These changes are required in order to resolve different problems during automatic conversion from Fase1 flows to Fase3 flows.

#### How Has This Been Tested?
 - Tested in UAT environment
 - Tested in PROD environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.