### PR TITLE
feat: [PIDM-504] update deploy config

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -5,14 +5,14 @@ version: 0.102.0
 appVersion: 1.0.10
 dependencies:
   - name: microservice-chart
-    version: 7.1.1
+    version: 8.0.2
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"
     alias: blobtrigger
   - name: microservice-chart
-    version: 7.1.1
+    version: 8.0.2
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"
     alias: queuetrigger
   - name: microservice-chart
-    version: 7.1.1
+    version: 8.0.2
     repository: "https://pagopa.github.io/aks-microservice-chart-blueprint"
     alias: httptrigger

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -18,8 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
+    replicas: 1 # (default) same as HPA minReplica
   serviceMonitor:
     create: true
     endpoints:

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -18,14 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # (default) same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   serviceMonitor:
     create: true
     endpoints:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -18,8 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
+    replicas: 1 # (default) same as HPA minReplica
   serviceMonitor:
     create: true
     endpoints:

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -18,14 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # (default) same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   serviceMonitor:
     create: true
     endpoints:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -18,8 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   deployment:
     create: true
+    replicas: 1 # (default) same as HPA minReplica
   serviceMonitor:
     create: true
     endpoints:

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -18,14 +18,14 @@ microservice-chart: &microservice-chart
     initialDelaySeconds: 30
     periodSeconds: 30
     failureThreshold: 10
-  strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
-      maxSurge: 1
   deployment:
     create: true
     replicas: 1 # (default) same as HPA minReplica
+    strategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 0
+        maxSurge: 1
   serviceMonitor:
     create: true
     endpoints:


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->

- upgraded helm chart to v8.0.2
- added rolling update strategy (maxUnavailable, maxSurge)
- overridden deployment replicas to match HPA minReplica config

NOTE: upgraded in

- DEV -> OK
- UAT -> OK
- PROD -> OK

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This upgrade was required to address an issue with the rollout strategy and the autoscaler behaviour, where the pods would scale down to 1 during deploy instead of keeping the same number of pods and doing +1 -1 to avoid traffic congestion. Also replicas are set to match the autoscaling config during deploy, to avoid starting the service with 1 pod when there is relevant traffic on the service.
This also ensures zero-downtime deployments by keeping all existing pods running until new versions are healthy and ready, then replacing them one at a time.

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

```
❯ helm dependency update
Getting updates for unmanaged Helm repositories...
...Successfully got an update from the "https://pagopa.github.io/aks-microservice-chart-blueprint" chart repository
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "bitnami" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 3 charts
Downloading microservice-chart from repo https://pagopa.github.io/aks-microservice-chart-blueprint
Already downloaded microservice-chart from repo https://pagopa.github.io/aks-microservice-chart-blueprint
Already downloaded microservice-chart from repo https://pagopa.github.io/aks-microservice-chart-blueprint
Deleting outdated charts
```

**VERY IMPORTANT**
The scripts needs to be adapted for every service and launched on each environment before actually upgrading through helm upgrade (ref. https://github.com/pagopa/aks-microservice-chart-blueprint/blob/main/scripts/migrate_from_v7_to_v8.sh)

```
❯ ../../migrate_from_v7_to_v8.sh pagopafdrxmltojson-blobtrigger pagopafdrxmltojson fdr
scaledobject.keda.sh/pagopafdrxmltojson-blobtrigger not labeled
scaledobject.keda.sh/pagopafdrxmltojson-blobtrigger not labeled
scaledobject.keda.sh/pagopafdrxmltojson-blobtrigger annotated
scaledobject.keda.sh/pagopafdrxmltojson-blobtrigger annotated
```
```
❯ ../../migrate_from_v7_to_v8.sh pagopafdrxmltojson-queuetrigger pagopafdrxmltojson fdr
scaledobject.keda.sh/pagopafdrxmltojson-queuetrigger not labeled
scaledobject.keda.sh/pagopafdrxmltojson-queuetrigger not labeled
scaledobject.keda.sh/pagopafdrxmltojson-queuetrigger annotated
scaledobject.keda.sh/pagopafdrxmltojson-queuetrigger annotated
```
```
❯ ../../migrate_from_v7_to_v8.sh pagopafdrxmltojson-httptrigger pagopafdrxmltojson fdr
scaledobject.keda.sh/pagopafdrxmltojson-httptrigger not labeled
scaledobject.keda.sh/pagopafdrxmltojson-httptrigger not labeled
scaledobject.keda.sh/pagopafdrxmltojson-httptrigger annotated
scaledobject.keda.sh/pagopafdrxmltojson-httptrigger annotated
```
```
❯ kubectl get scaledobject pagopafdrxmltojson-blobtrigger -n fdr -o jsonpath='{.metadata.labels}' | jq
{
  "app.kubernetes.io/instance": "pagopafdrxmltojson",
  "app.kubernetes.io/managed-by": "Helm",
  "app.kubernetes.io/name": "blobtrigger",
  "app.kubernetes.io/version": "1.0.9-1-PAGOPA-2800-fd-r-sampling-dei-log-su-ai-e-elk",
  "azure.workload.identity/use": "true",
  "canaryDelivery": "false",
  "helm.sh/blueprint-version": "7.1.1",
  "helm.sh/chart": "blobtrigger-1.0.9-1-PAGOPA-2800-fd-r-sampling-dei-log-su-ai-e-e",
  "scaledobject.keda.sh/name": "pagopafdrxmltojson-blobtrigger"
}
```
```
❯ kubectl get scaledobject pagopafdrxmltojson-blobtrigger -n fdr -o jsonpath='{.metadata.annotations}' | jq
{
  "helm.sh/hook": "post-install ,post-upgrade",
  "meta.helm.sh/release-name": "pagopafdrxmltojson",
  "meta.helm.sh/release-namespace": "fdr"
}
```
```
❯ kubectl delete scaledobject pagopafdrxmltojson-blobtrigger -n fdr
scaledobject.keda.sh "pagopafdrxmltojson-blobtrigger" deleted from fdr namespace
❯ kubectl delete scaledobject pagopafdrxmltojson-queuetrigger -n fdr
scaledobject.keda.sh "pagopafdrxmltojson-queuetrigger" deleted from fdr namespace
❯ kubectl delete scaledobject pagopafdrxmltojson-httptrigger -n fdr
scaledobject.keda.sh "pagopafdrxmltojson-httptrigger" deleted from fdr namespace
```
```
❯ helm upgrade --namespace fdr \
    --install --values ./values-dev.yaml \
    --set blobtrigger.azure.workloadIdentityClientId=xxxxx \
    --set queuetrigger.azure.workloadIdentityClientId=xxxxx \
    --set httptrigger.azure.workloadIdentityClientId=xxxxx \
    --set blobtrigger.podAnnotations.force-rollout="rollout-$(date +%s)" \
    --set queuetrigger.podAnnotations.force-rollout="rollout-$(date +%s)" \
    --set httptrigger.podAnnotations.force-rollout="rollout-$(date +%s)" \
    --wait --timeout 15m0s \
    pagopafdrxmltojson .
Release "pagopafdrxmltojson" has been upgraded. Happy Helming!
NAME: pagopafdrxmltojson
LAST DEPLOYED: Thu Oct 16 10:56:07 2025
NAMESPACE: fdr
STATUS: deployed
REVISION: 25
TEST SUITE: None
```
```
❯ kubectl get scaledobject pagopafdrxmltojson-blobtrigger -n fdr -o jsonpath='{.metadata.labels.helm\.sh/blueprint-version}'
8.0.2%
```
```
❯ kubectl get pods -n fdr -l app.kubernetes.io/instance=pagopafdrxmltojson
NAME                                              READY   STATUS    RESTARTS   AGE
pagopafdrxmltojson-blobtrigger-759bbbd577-sc6qx   1/1     Running   0          119s
pagopafdrxmltojson-httptrigger-75cfdd6757-ssrw5   1/1     Running   0          119s
pagopafdrxmltojson-queuetrigger-7879fc87b-zq9m6   1/1     Running   0          119s
```
```
❯ kubectl get pods,hpa,scaledobject -n fdr -l app.kubernetes.io/instance=pagopafdrxmltojson
NAME                                                  READY   STATUS    RESTARTS   AGE
pod/pagopafdrxmltojson-blobtrigger-759bbbd577-sc6qx   1/1     Running   0          2m7s
pod/pagopafdrxmltojson-httptrigger-75cfdd6757-ssrw5   1/1     Running   0          2m7s
pod/pagopafdrxmltojson-queuetrigger-7879fc87b-zq9m6   1/1     Running   0          2m7s

NAME                                                                           REFERENCE                                    TARGETS              MINPODS   MAXPODS   REPLICAS   AGE
horizontalpodautoscaler.autoscaling/keda-hpa-pagopa-fdr-xml-to-json            Deployment/pagopa-fdr-xml-to-json            cpu: 2%/75%          1         1         1          205d
horizontalpodautoscaler.autoscaling/keda-hpa-pagopafdrxmltojson-blobtrigger    Deployment/pagopafdrxmltojson-blobtrigger    cpu: <unknown>/75%   1         1         1          2m6s
horizontalpodautoscaler.autoscaling/keda-hpa-pagopafdrxmltojson-httptrigger    Deployment/pagopafdrxmltojson-httptrigger    cpu: <unknown>/75%   1         1         1          2m6s
horizontalpodautoscaler.autoscaling/keda-hpa-pagopafdrxmltojson-queuetrigger   Deployment/pagopafdrxmltojson-queuetrigger   cpu: <unknown>/75%   1         1         1          2m6s

NAME                                                   SCALETARGETKIND      SCALETARGETNAME                   MIN   MAX   READY   ACTIVE    FALLBACK   PAUSED    TRIGGERS   AUTHENTICATIONS                   AGE
scaledobject.keda.sh/pagopa-fdr-xml-to-json            apps/v1.Deployment   pagopa-fdr-xml-to-json            1     1     False   Unknown   False      Unknown                                                205d
scaledobject.keda.sh/pagopafdrxmltojson-blobtrigger    apps/v1.Deployment   pagopafdrxmltojson-blobtrigger    1     1     True    True      False      Unknown   cpu        pagopafdrxmltojson-blobtrigger    2m6s
scaledobject.keda.sh/pagopafdrxmltojson-httptrigger    apps/v1.Deployment   pagopafdrxmltojson-httptrigger    1     1     True    True      False      Unknown   cpu        pagopafdrxmltojson-httptrigger    2m6s
scaledobject.keda.sh/pagopafdrxmltojson-queuetrigger   apps/v1.Deployment   pagopafdrxmltojson-queuetrigger   1     1     True    True      False      Unknown   cpu        pagopafdrxmltojson-queuetrigger   2m6s
```
#### Screenshots (if appropriate):

#### Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
