### PR TITLE
fix: [PIDM-1195] Levelled all `fdrDate` values to UTC format

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: pagopa-fdr-xml-to-json
 description: AppFn to convert SOAP FdR to JSON FdR
-version: 0.103.0
-appVersion: 1.0.11
+version: 0.104.0
+appVersion: 1.0.11-1-PIDM-1195
 dependencies:
   - name: microservice-chart
     version: 8.0.2

--- a/helm/values-dev.yaml
+++ b/helm/values-dev.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-xml-to-json
-    tag: "1.0.11"
+    tag: "1.0.11-1-PIDM-1195"
     pullPolicy: Always
   livenessProbe:
     handlerType: tcpSocket

--- a/helm/values-prod.yaml
+++ b/helm/values-prod.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-xml-to-json
-    tag: "1.0.11"
+    tag: "1.0.11-1-PIDM-1195"
     pullPolicy: Always
   livenessProbe:
     handlerType: tcpSocket

--- a/helm/values-uat.yaml
+++ b/helm/values-uat.yaml
@@ -2,7 +2,7 @@ microservice-chart: &microservice-chart
   namespace: "fdr"
   image:
     repository: ghcr.io/pagopa/pagopa-fdr-xml-to-json
-    tag: "1.0.11"
+    tag: "1.0.11-1-PIDM-1195"
     pullPolicy: Always
   livenessProbe:
     handlerType: tcpSocket

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "FdR - XML to JSON ${service}",
-    "version": "1.0.11",
+    "version": "1.0.11-1-PIDM-1195",
     "description": "FDR XML to JSON API REST"
   },
   "paths": {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>fdrxmltojson</artifactId>
-    <version>1.0.11</version>
+    <version>1.0.11-1-PIDM-1195</version>
     <packaging>jar</packaging>
 
     <name>FDR XML to JSON Fn</name>

--- a/src/main/java/it/gov/pagopa/fdrxmltojson/util/FdR3ClientUtil.java
+++ b/src/main/java/it/gov/pagopa/fdrxmltojson/util/FdR3ClientUtil.java
@@ -9,6 +9,11 @@ import org.openapitools.client.ApiClient;
 import org.openapitools.client.api.InternalPspApi;
 import org.openapitools.client.model.*;
 
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -51,7 +56,7 @@ public class FdR3ClientUtil {
     public CreateRequest getCreateRequest(NodoInviaFlussoRendicontazioneRequest nodoInviaFlussoRendicontazioneRequest, CtFlussoRiversamento ctFlussoRiversamento){
         CreateRequest createRequest = new CreateRequest();
         createRequest.setFdr(nodoInviaFlussoRendicontazioneRequest.getIdentificativoFlusso());
-        createRequest.setFdrDate(nodoInviaFlussoRendicontazioneRequest.getDataOraFlusso().toGregorianCalendar().toZonedDateTime().toOffsetDateTime());
+        createRequest.setFdrDate(nodoInviaFlussoRendicontazioneRequest.getDataOraFlusso().toGregorianCalendar().toZonedDateTime().toOffsetDateTime().withOffsetSameLocal(ZoneOffset.UTC));
         createRequest.setSender(getSender(nodoInviaFlussoRendicontazioneRequest, ctFlussoRiversamento));
         createRequest.setReceiver(getReceiver(nodoInviaFlussoRendicontazioneRequest, ctFlussoRiversamento));
         createRequest.setRegulation(ctFlussoRiversamento.getIdentificativoUnivocoRegolamento());


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
 - Excluded explicit timezone reference during conversion 

#### Motivation and Context
This change resolve an issue on conversion for `dataOraFlusso` fields with explicit timezones. Previously, when PSPs send a FdR on Fase1 application, some of them send also the timezone in the flow date. This caused the automatic conversion system to send the same timezone on Fase3 application that convert it in UTC timezone, causing drifts on the two kind of data in the different DBs.

#### How Has This Been Tested?
 - Tested in local environment
 - Tested in UAT environment

#### Screenshots (if appropriate):
**_Fase 1_**
<img width="1344" height="510" alt="image" src="https://github.com/user-attachments/assets/059d9849-dbb8-48ad-8aaa-e56920b223fa" />

**_Fase 3_**
<img width="1176" height="474" alt="image" src="https://github.com/user-attachments/assets/b06713d7-5329-47e1-8927-d419cce6d735" />

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.